### PR TITLE
Mini batch HashNet.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+save/
+__pycache__/


### PR DESCRIPTION
更改了 HashNet 计算 loss 的方式. 
更改之前，计算 `similarity` 需要和全体训练数据进行计算。更改之后只需要和当前 batch 内的样本进行计算。
加速了训练过程，使得 HashNet 在大数据集上训练速度提升。
测试了 cifar10-1 和 imagenet100 两个数据集，精度无变化。
